### PR TITLE
Print tar output, add overwrite flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/appleboy/easyssh-proxy"
+	easyssh "github.com/appleboy/easyssh-proxy"
 	"github.com/joho/godotenv"
 	_ "github.com/joho/godotenv/autoload"
 	"github.com/urfave/cli"
@@ -82,6 +82,11 @@ func main() {
 			Name:   "source, s",
 			Usage:  "scp file list",
 			EnvVar: "PLUGIN_SOURCE,SCP_SOURCE",
+		},
+		cli.BoolFlag{
+			Name:   "overwrite",
+			Usage:  "use --overwrite flag with tar",
+			EnvVar: "PLUGIN_OVERWRITE,SCP_OVERWRITE",
 		},
 		cli.BoolFlag{
 			Name:   "rm, r",
@@ -263,6 +268,7 @@ func run(c *cli.Context) error {
 			KeyPath:         c.String("key-path"),
 			Target:          c.StringSlice("target"),
 			Source:          c.StringSlice("source"),
+			Overwrite:       c.Bool("overwrite"),
 			Remove:          c.Bool("rm"),
 			StripComponents: c.Int("strip.components"),
 			Proxy: easyssh.DefaultConfig{

--- a/plugin.go
+++ b/plugin.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/appleboy/com/random"
-	"github.com/appleboy/easyssh-proxy"
+	easyssh "github.com/appleboy/easyssh-proxy"
 	"github.com/fatih/color"
 )
 
@@ -47,6 +47,7 @@ type (
 		CommandTimeout  int
 		Target          []string
 		Source          []string
+		Overwrite       bool
 		Remove          bool
 		StripComponents int
 		Proxy           easyssh.DefaultConfig
@@ -255,11 +256,18 @@ func (p *Plugin) Exec() error {
 
 				// untar file
 				p.log(host, "untar file", p.DestFile)
+
+				overwriteFlag := ""
+				if p.Config.Overwrite {
+					p.log(host, "overwriting existing files")
+					overwriteFlag = "--overwrite "
+				}
+
 				var outStr string
 				if p.Config.StripComponents > 0 {
-					outStr, errStr, _, err = ssh.Run(fmt.Sprintf("tar -vvv -xf %s --strip-components=%d -C %s", p.DestFile, p.Config.StripComponents, target), p.Config.CommandTimeout)
+					outStr, errStr, _, err = ssh.Run(fmt.Sprintf("tar %s-vvv -xf %s --strip-components=%d -C %s", overwriteFlag, p.DestFile, p.Config.StripComponents, target), p.Config.CommandTimeout)
 				} else {
-					outStr, errStr, _, err = ssh.Run(fmt.Sprintf("tar -vvv -xf %s -C %s", p.DestFile, target), p.Config.CommandTimeout)
+					outStr, errStr, _, err = ssh.Run(fmt.Sprintf("tar %s-vvv -xf %s -C %s", overwriteFlag, p.DestFile, target), p.Config.CommandTimeout)
 				}
 
 				p.log(host, "output: ", outStr)

--- a/plugin.go
+++ b/plugin.go
@@ -255,10 +255,17 @@ func (p *Plugin) Exec() error {
 
 				// untar file
 				p.log(host, "untar file", p.DestFile)
+				var outStr string
 				if p.Config.StripComponents > 0 {
-					_, _, _, err = ssh.Run(fmt.Sprintf("tar -xf %s --strip-components=%d -C %s", p.DestFile, p.Config.StripComponents, target), p.Config.CommandTimeout)
+					outStr, errStr, _, err = ssh.Run(fmt.Sprintf("tar -vvv -xf %s --strip-components=%d -C %s", p.DestFile, p.Config.StripComponents, target), p.Config.CommandTimeout)
 				} else {
-					_, _, _, err = ssh.Run(fmt.Sprintf("tar -xf %s -C %s", p.DestFile, target), p.Config.CommandTimeout)
+					outStr, errStr, _, err = ssh.Run(fmt.Sprintf("tar -vvv -xf %s -C %s", p.DestFile, target), p.Config.CommandTimeout)
+				}
+
+				p.log(host, "output: ", outStr)
+
+				if errStr != "" {
+					p.log(host, "error: ", errStr)
 				}
 
 				if err != nil {


### PR DESCRIPTION
Some time I had to debug some mysterious tar error during deploys, which I solved by having a verbose output and the option to use the tar `--overwrite` flag

Are you interested in merging those changes? I can look into adding a flag for verbose output and implement some tests

Let me know!
