### PR TITLE
Add TarExec parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,6 +187,12 @@ func main() {
 			Usage:  "Remove the specified number of leading path elements.",
 			EnvVar: "PLUGIN_STRIP_COMPONENTS,TAR_STRIP_COMPONENTS",
 		},
+		cli.StringFlag{
+			Name:   "tar.exec",
+			Usage:  "Alternative `tar` executable to on the dest host",
+			EnvVar: "PLUGIN_TAR_EXEC,SCP_TAR_EXEC",
+			Value:  "tar",
+		},
 	}
 
 	// Override a template
@@ -265,6 +271,7 @@ func run(c *cli.Context) error {
 			Source:          c.StringSlice("source"),
 			Remove:          c.Bool("rm"),
 			StripComponents: c.Int("strip.components"),
+			TarExec:         c.String("tar.exec"),
 			Proxy: easyssh.DefaultConfig{
 				Key:      c.String("proxy.ssh-key"),
 				KeyPath:  c.String("proxy.key-path"),

--- a/plugin.go
+++ b/plugin.go
@@ -255,7 +255,7 @@ func (p *Plugin) Exec() error {
 				}
 
 				// untar file
-				p.log(host, "untar file")
+				p.log(host, "untar file", p.DestFile)
 				if p.Config.StripComponents > 0 {
 					_, _, _, err = ssh.Run(fmt.Sprintf("%s -xf %s --strip-components=%d -C %s", p.Config.TarExec, p.DestFile, p.Config.StripComponents, target), p.Config.CommandTimeout)
 				} else {

--- a/plugin.go
+++ b/plugin.go
@@ -49,6 +49,7 @@ type (
 		Source          []string
 		Remove          bool
 		StripComponents int
+		TarExec         string
 		Proxy           easyssh.DefaultConfig
 	}
 
@@ -254,11 +255,11 @@ func (p *Plugin) Exec() error {
 				}
 
 				// untar file
-				p.log(host, "untar file", p.DestFile)
+				p.log(host, "untar file")
 				if p.Config.StripComponents > 0 {
-					_, _, _, err = ssh.Run(fmt.Sprintf("tar -xf %s --strip-components=%d -C %s", p.DestFile, p.Config.StripComponents, target), p.Config.CommandTimeout)
+					_, _, _, err = ssh.Run(fmt.Sprintf("%s -xf %s --strip-components=%d -C %s", p.Config.TarExec, p.DestFile, p.Config.StripComponents, target), p.Config.CommandTimeout)
 				} else {
-					_, _, _, err = ssh.Run(fmt.Sprintf("tar -xf %s -C %s", p.DestFile, target), p.Config.CommandTimeout)
+					_, _, _, err = ssh.Run(fmt.Sprintf("%s -xf %s -C %s", p.Config.TarExec, p.DestFile, target), p.Config.CommandTimeout)
 				}
 
 				if err != nil {


### PR DESCRIPTION
Add TarExec parameter to provide an alternative tar-command (E.g. On old non-Linux systems it may be necessary to use gtar).