### PR TITLE
Add variable to set temporary tar upload path

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,6 +193,11 @@ func main() {
 			EnvVar: "PLUGIN_TAR_EXEC,SCP_TAR_EXEC",
 			Value:  "tar",
 		},
+		cli.StringFlag{
+			Name:   "tar.tmp-path",
+			Usage:  "Temporary path for tar file on the dest host",
+			EnvVar: "PLUGIN_TAR_TMP_PATH,SCP_TAR_TMP_PATH",
+		},
 		cli.BoolFlag{
 			Name:   "debug",
 			Usage:  "remove target folder before upload data",
@@ -273,6 +278,7 @@ func run(c *cli.Context) error {
 			Debug:           c.Bool("debug"),
 			StripComponents: c.Int("strip.components"),
 			TarExec:         c.String("tar.exec"),
+			TarTmpPath:      c.String("tar.tmp-path"),
 			Proxy: easyssh.DefaultConfig{
 				Key:      c.String("proxy.ssh-key"),
 				KeyPath:  c.String("proxy.key-path"),

--- a/plugin.go
+++ b/plugin.go
@@ -57,6 +57,7 @@ type (
 		Remove          bool
 		StripComponents int
 		TarExec         string
+		TarTmpPath      string
 		Proxy           easyssh.DefaultConfig
 		Debug           bool
 	}
@@ -260,6 +261,9 @@ func (p *Plugin) Exec() error {
 					Timeout:  p.Config.Proxy.Timeout,
 				},
 			}
+
+			// upload file to the tmp path
+			p.DestFile = fmt.Sprintf("%s%s", p.Config.TarTmpPath, p.DestFile)
 
 			// Call Scp method with file you want to upload to remote server.
 			p.log(host, "scp file to server.")


### PR DESCRIPTION
I stumbled on a situation where I didn't have permissions to write to the default path for the .tar file upload on the target host. It made drone-scp unusable for my use case.

This pull request adds the capability to change the path the .tar file is uploaded to. It's been fully tested and it resolves the issue I mentioned above.