### PR TITLE
Fix typo in EnvVars for ssh-passphrase

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,7 +159,7 @@ func main() {
 		&cli.StringFlag{
 			Name:    "proxy.ssh-passphrase",
 			Usage:   "The purpose of the passphrase is usually to encrypt the private key.",
-			EnvVars: []string{"PLUGIN_PROXY_SSH_PASSPHRASE", "PLUGIN_PROXY_PASSPHRASE", "PROXY_SSH_PASSPHRASE,PROXY_PASSPHRASE", "INPUT_PROXY_PASSPHRASE"},
+			EnvVars: []string{"PLUGIN_PROXY_SSH_PASSPHRASE", "PLUGIN_PROXY_PASSPHRASE", "PROXY_SSH_PASSPHRASE", "PROXY_PASSPHRASE", "INPUT_PROXY_PASSPHRASE"},
 		},
 		&cli.StringFlag{
 			Name:    "proxy.key-path",


### PR DESCRIPTION
Noticed this typo when I couldn't set the key password for the proxy.  Worked around by using one of the other ENV name options, but figured it might help others to submit a PR with a fix.