### PR TITLE
Adding feature to check if shell is bash or windows cli.

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -361,7 +361,7 @@ func (p *Plugin) Exec() error {
 				mkdircmd := ""
 				switch systemType {
 				case "windows":
-					mkdircmd = fmt.Sprintf("if not exist %s mkdir %s", target)
+					mkdircmd = fmt.Sprintf("if not exist %s mkdir %s", target, target)
 				case "unix":
 					mkdircmd = fmt.Sprintf("mkdir -p %s", target)
 				}


### PR DESCRIPTION
Closes #111 
Closes https://github.com/appleboy/scp-action/issues/39

Possibly Closes: https://github.com/appleboy/scp-action/issues/3

Related Comment: https://github.com/appleboy/drone-scp/issues/50#issuecomment-676610485

Once this check passes, it will use commands specific command to it's operating shell. For example, at the command `rm -rf %s` would not work on either terminals, cause -rf is not a valid argument, the command exists for powershell, but not on the normal windows command line. So you would have to change that to `DEL` command isntead, which is supported by both powershell and windows command line.

Another fix is added is mkdir, though mkdir exists for the commandline, it returns an error when the folder already exists, and the -p argument is not valid for mkdir, and instead creates an actual folder called `-p`. This is why we use `if not exist %s mkdir %s`, cause it checks if that folder exists before creating it. This works on the windows command line, but not on powershell, but if we can, we could also add a check for powershell and use a powershell command instead.