### PR TITLE
feat(tar): add unlink-first flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -250,6 +250,11 @@ func main() {
 			Usage:   "use --overwrite flag with tar",
 			EnvVars: []string{"PLUGIN_OVERWRITE", "SCP_OVERWRITE", "INPUT_OVERWRITE"},
 		},
+		&cli.BoolFlag{
+			Name:    "unlink.first",
+			Usage:   "use --unlink-first flag with tar",
+			EnvVars: []string{"PLUGIN_UNLINK_FIRST", "SCP_UNLINK_FIRST", "INPUT_UNLINK_FIRST"},
+		},
 	}
 
 	// Override a template
@@ -325,6 +330,7 @@ func run(c *cli.Context) error {
 			TarExec:           c.String("tar.exec"),
 			TarTmpPath:        c.String("tar.tmp-path"),
 			Overwrite:         c.Bool("overwrite"),
+			UnlinkFirst:       c.Bool("unlink.first"),
 			Ciphers:           c.StringSlice("ciphers"),
 			UseInsecureCipher: c.Bool("useInsecureCipher"),
 			Proxy: easyssh.DefaultConfig{

--- a/plugin.go
+++ b/plugin.go
@@ -64,6 +64,7 @@ type (
 		Proxy             easyssh.DefaultConfig
 		Debug             bool
 		Overwrite         bool
+		UnlinkFirst       bool
 		Ciphers           []string
 		UseInsecureCipher bool
 	}
@@ -224,6 +225,10 @@ func (p *Plugin) buildArgs(target string) []string {
 
 	if p.Config.Overwrite {
 		args = append(args, "--overwrite")
+	}
+
+	if p.Config.UnlinkFirst {
+		args = append(args, "--unlink-first")
 	}
 
 	args = append(args,

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -639,8 +639,9 @@ func TestPlugin_buildArgs(t *testing.T) {
 			name: "default command",
 			fields: fields{
 				Config: Config{
-					Overwrite: false,
-					TarExec:   "tar",
+					Overwrite:   false,
+					UnlinkFirst: false,
+					TarExec:     "tar",
 				},
 				DestFile: "foo.tar",
 			},
@@ -654,6 +655,7 @@ func TestPlugin_buildArgs(t *testing.T) {
 			fields: fields{
 				Config: Config{
 					Overwrite:       false,
+					UnlinkFirst:     false,
 					TarExec:         "tar",
 					StripComponents: 2,
 				},
@@ -671,6 +673,7 @@ func TestPlugin_buildArgs(t *testing.T) {
 					TarExec:         "tar",
 					StripComponents: 2,
 					Overwrite:       true,
+					UnlinkFirst:     false,
 				},
 				DestFile: "foo.tar",
 			},
@@ -678,6 +681,22 @@ func TestPlugin_buildArgs(t *testing.T) {
 				target: "foo",
 			},
 			want: []string{"tar", "-xf", "foo.tar", "--strip-components", "2", "--overwrite", "-C", "foo"},
+		},
+		{
+			name: "unlink first",
+			fields: fields{
+				Config: Config{
+					TarExec:         "tar",
+					StripComponents: 2,
+					Overwrite:       true,
+					UnlinkFirst:     true,
+				},
+				DestFile: "foo.tar",
+			},
+			args: args{
+				target: "foo",
+			},
+			want: []string{"tar", "-xf", "foo.tar", "--strip-components", "2", "--overwrite", "--unlink-first", "-C", "foo"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Adds option to unlink symlinks first before extracting with `tar`, the existing `overwrite` option doesn't work with symlinks.

from `man tar`
```
       -U, --unlink-first
              Remove each file prior to extracting over it.
```

