### PR TITLE
test: check ignore list function working or not.

### DIFF
--- a/plugin_test.go
+++ b/plugin_test.go
@@ -74,12 +74,12 @@ func TestTrimElement(t *testing.T) {
 	input = []string{"1", "     ", "3"}
 	result = []string{"1", "3"}
 
-	assert.Equal(t, result, trimPath(input))
+	assert.Equal(t, result, trimValues(input))
 
 	input = []string{"1", "2"}
 	result = []string{"1", "2"}
 
-	assert.Equal(t, result, trimPath(input))
+	assert.Equal(t, result, trimValues(input))
 }
 
 func TestSCPFileFromPublicKey(t *testing.T) {


### PR DESCRIPTION
- Modify the `assert` function call to use `trimValues` instead of `trimPath`

fix https://github.com/appleboy/drone-scp/issues/133