### PR TITLE
build: compress build artifacts using gzip

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -120,7 +120,7 @@ func buildArgs(tar string, files fileList) []string {
 			args = append(args, v)
 		}
 	}
-	args = append(args, "-cf")
+	args = append(args, "-zcf")
 	args = append(args, getRealPath(tar))
 	args = append(args, files.Source...)
 
@@ -254,7 +254,7 @@ func (p *Plugin) Exec() error {
 	}
 
 	files := globList(trimValues(p.Config.Source))
-	p.DestFile = fmt.Sprintf("%s.tar", random.String(10))
+	p.DestFile = fmt.Sprintf("%s.tar.gz", random.String(10))
 
 	// create a temporary file for the archive
 	dir := os.TempDir()

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -579,7 +579,7 @@ func TestBuildArgs(t *testing.T) {
 	}
 
 	result := buildArgs("test.tar.gz", list)
-	expects := []string{"--exclude", "tests/a.txt", "--exclude", "tests/b.txt", "-cf", "test.tar.gz", "tests/a.txt", "tests/b.txt", "tests/c.txt"}
+	expects := []string{"--exclude", "tests/a.txt", "--exclude", "tests/b.txt", "-zcf", "test.tar.gz", "tests/a.txt", "tests/b.txt", "tests/c.txt"}
 	assert.Equal(t, expects, result)
 
 	list = fileList{
@@ -587,7 +587,7 @@ func TestBuildArgs(t *testing.T) {
 	}
 
 	result = buildArgs("test.tar.gz", list)
-	expects = []string{"-cf", "test.tar.gz", "tests/a.txt", "tests/b.txt"}
+	expects = []string{"-zcf", "test.tar.gz", "tests/a.txt", "tests/b.txt"}
 	assert.Equal(t, expects, result)
 }
 


### PR DESCRIPTION
- Change the compression format from `tar` to `tar.gz`
- Replace the flag `-cf` with `-zcf` in the `buildArgs` function

fix https://github.com/appleboy/drone-scp/issues/123