### PR TITLE
fix: improve support for folder names with spaces

### DIFF
--- a/command.go
+++ b/command.go
@@ -5,7 +5,7 @@ func rmcmd(os, target string) string {
 	case "windows":
 		return "DEL /F /S " + target
 	case "unix":
-		return "rm -rf " + target
+		return "rm -rf '" + target + "'"
 	}
 	return ""
 }
@@ -15,7 +15,7 @@ func mkdircmd(os, target string) string {
 	case "windows":
 		return "if not exist " + target + " mkdir " + target
 	case "unix":
-		return "mkdir -p " + target
+		return "mkdir -p '" + target + "'"
 	}
 
 	return ""

--- a/plugin.go
+++ b/plugin.go
@@ -234,7 +234,7 @@ func (p *Plugin) buildUnTarArgs(target string) []string {
 
 	args = append(args,
 		"-C",
-		target,
+		"'"+target+"'",
 	)
 
 	return args


### PR DESCRIPTION
- Add a test for a target folder with spaces in the name
- Fix a bug in the `buildUnTarArgs` function that caused it to fail when receiving a target with spaces
- Remove unused code in the `TestRemoveDestFile` function

ref https://github.com/appleboy/scp-action/issues/85