### PR TITLE
refactor: remove unnecessary quotes in plugin build process

### DIFF
--- a/command.go
+++ b/command.go
@@ -5,7 +5,7 @@ func rmcmd(os, target string) string {
 	case "windows":
 		return "DEL /F /S " + target
 	case "unix":
-		return "rm -rf '" + target + "'"
+		return "rm -rf " + target
 	}
 	return ""
 }
@@ -15,7 +15,7 @@ func mkdircmd(os, target string) string {
 	case "windows":
 		return "if not exist " + target + " mkdir " + target
 	case "unix":
-		return "mkdir -p '" + target + "'"
+		return "mkdir -p " + target
 	}
 
 	return ""

--- a/plugin.go
+++ b/plugin.go
@@ -209,7 +209,7 @@ func (p *Plugin) buildUnTarArgs(target string) []string {
 
 	args = append(args,
 		"-C",
-		"'"+target+"'",
+		target,
 	)
 
 	return args
@@ -304,6 +304,7 @@ func (p *Plugin) Exec() error {
 			}
 
 			for _, target := range p.Config.Target {
+				target = strings.Replace(target, " ", "\\ ", -1)
 				// remove target folder before upload data
 				if p.Config.Remove {
 					p.log(host, "Remove target folder:", target)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -615,7 +615,7 @@ func TestPlugin_buildUnTarArgs(t *testing.T) {
 			args: args{
 				target: "foo",
 			},
-			want: []string{"tar", "-zxf", "foo.tar.gz", "-C", "'foo'"},
+			want: []string{"tar", "-zxf", "foo.tar.gz", "-C", "foo"},
 		},
 		{
 			name: "strip components",
@@ -631,7 +631,7 @@ func TestPlugin_buildUnTarArgs(t *testing.T) {
 			args: args{
 				target: "foo",
 			},
-			want: []string{"tar", "-zxf", "foo.tar.gz", "--strip-components", "2", "-C", "'foo'"},
+			want: []string{"tar", "-zxf", "foo.tar.gz", "--strip-components", "2", "-C", "foo"},
 		},
 		{
 			name: "overwrite",
@@ -647,7 +647,7 @@ func TestPlugin_buildUnTarArgs(t *testing.T) {
 			args: args{
 				target: "foo",
 			},
-			want: []string{"tar", "-zxf", "foo.tar.gz", "--strip-components", "2", "--overwrite", "-C", "'foo'"},
+			want: []string{"tar", "-zxf", "foo.tar.gz", "--strip-components", "2", "--overwrite", "-C", "foo"},
 		},
 		{
 			name: "unlink first",
@@ -663,7 +663,7 @@ func TestPlugin_buildUnTarArgs(t *testing.T) {
 			args: args{
 				target: "foo",
 			},
-			want: []string{"tar", "-zxf", "foo.tar.gz", "--strip-components", "2", "--overwrite", "--unlink-first", "-C", "'foo'"},
+			want: []string{"tar", "-zxf", "foo.tar.gz", "--strip-components", "2", "--overwrite", "--unlink-first", "-C", "foo"},
 		},
 		{
 			name: "output folder path with space",
@@ -677,9 +677,9 @@ func TestPlugin_buildUnTarArgs(t *testing.T) {
 				DestFile: "foo.tar.gz",
 			},
 			args: args{
-				target: "foo bar",
+				target: "foo\\ bar",
 			},
-			want: []string{"tar", "-zxf", "foo.tar.gz", "--strip-components", "2", "--overwrite", "--unlink-first", "-C", "'foo bar'"},
+			want: []string{"tar", "-zxf", "foo.tar.gz", "--strip-components", "2", "--overwrite", "--unlink-first", "-C", "foo\\ bar"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
- Modify `rmcmd` and `mkdircmd` to remove unneeded quotes
- Update `buildUnTarArgs` in `plugin.go` to use target without quotes
- Add `Exec` function to `plugin.go` with `strings.Replace` call
- Update tests in `plugin_test.go` to use target without quotes

ref: https://github.com/appleboy/scp-action/issues/112