### PR TITLE
Add option to exclude parent directory when using * wildcard for scp-action

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -196,13 +196,13 @@ func (p *Plugin) buildTarArgs(src string) []string {
 			if strings.HasPrefix(files.Source[i], "!") {
 				comparePath = comparePath[1:]
 			}
-			for !strings.HasPrefix(comparePath, basePrefix) {
-				lastSlashIdx := strings.LastIndex(basePrefix, string(os.PathSeparator))
-				if lastSlashIdx == -1 {
+			basePrefixWithSlash := basePrefix + string(os.PathSeparator)
+			for !strings.HasPrefix(comparePath, basePrefixWithSlash) {
+				basePrefix = filepath.Dir(basePrefix)
+				if basePrefix == "." {
 					hasCommonFolder = false // if Source[i] doesn't have same prefix
 					break
 				}
-				basePrefix = basePrefix[:lastSlashIdx] // shrink prefix range
 			}
 		}
 	} else {


### PR DESCRIPTION
# Modification explanation

Using [scp-action](https://github.com/appleboy/scp-action?tab=readme-ov-file#example-1-basic-ssh-password), I found that this action also copy the parent(top) folder of the source when I wrote source like `dist/*`.

<img width="534" height="307" alt="스크린샷 2025-07-26 042254" src="https://github.com/user-attachments/assets/dea47638-7aea-4e23-ab48-5000401561b8" />

And the result is:

<img width="700" height="477" alt="스크린샷 2025-07-26 035957" src="https://github.com/user-attachments/assets/983fe165-52f0-4ea4-9361-8aad4cb5dcfc" />

This image shows that the scp-action has copied file to target folder of my remote server, but it is in the `dist` folder.
I thought it'll be nice to add an option for the situation setting source files with one folder and asterisk wildcard to drone-scp.
This PR implemented it.

<img width="712" height="264" alt="스크린샷 2025-07-26 042222" src="https://github.com/user-attachments/assets/8c7ab308-fc5e-4fc9-9ef8-09b4b4f8dc8d" />

(The dist folder still exist because I didn't removed it. This code just works well 👍)
This time, I used [modified scp-action](https://github.com/ForestHouse2316/scp-action-test-for-drone) which downloads [forked version of drone-scp](https://github.com/ForestHouse2316/drone-scp-tar-modify).
With same source and target setting, scp-action only copied and overwritten the files ***IN*** the `dist` folder.

# Additional example
- if input is [ f/s/a.txt , f/s/b.txt ] then make this to [ a.txt , b.txt ]
- if input is [ f/a.txt , f/s/b.txt ] then make this to [ a.txt , s/b.txt ]
- [ a.txt , f/s/b.txt ] -> nothing change
- [ f/a.txt , !f/b.txt ] -> [ a.txt , !b.txt ]
- [ folder1/a.txt , folder2/b.txt ] -> nothing change

# Points for improvements

## Serve this function as an option
Because this function is made from needs about scp-action, it might not so useful when using only drone-scp.
So I think this function should be able to be turned off by the option.

## Unit test fail
Current unittest system is working on the premise that drone-scp preserves all folder structure when input is `[ top/a.txt , top/b.txt ]`.
But this function doesn't preserve the folder `top` in this case.
Therefore, at first, function on/off option is needed.
And making a new unit test for the function turned on situation is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of source file paths when creating tar archives, resulting in more efficient packaging when files share a common base directory.
  * Enhanced error handling for paths that cannot be processed, with clear error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->